### PR TITLE
change postgres to latest stable alpine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2.3'
 services:
   postgres:
     container_name: diaspora_postgres
-    image: postgres:9.6-alpine
+    image: postgres:13-alpine3.14
     restart: always
     volumes:
       - ./postgres:/var/lib/postgresql/data


### PR DESCRIPTION
Fixes #46 

In the off chance that anyone has used this docker-compose in production, here's what worked for a test instance and will be done to dogieda.org in the next couple of days.

### Upgrading db from 9.6 to 13.4 (first docker-compose to modern one)
```sh
docker exec diaspora_postgres pg_dumpall -U diaspora > dump.sql
vi dump.sql    #check that this has the data you'd expect
docker-compose down
sudo mv postgres postgres-9.6.   # keeping a copy so you can change back without export
#
# stop here and edit your existing docker-compose to use the new postgres version
#
docker-compose up postgres    # leaving stdout connected to watch what happens

# in another terminal
docker-compose run --rm unicorn bin/rake db:create
sudo cp dump.sql postgres

# get into postgres container to run db import
docker exec -it diaspora_postgres bash
su - postgres
psql -f /var/lib/postgresql/data/dump.sql -U diaspora diaspora_production
# exit twice to get back to host terminal
docker-compose up -d     # final startup
```